### PR TITLE
Node 10 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-typed-json",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-typed-json",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "JSON types and utilities for TypeScript.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import { readFile } from 'fs/promises';
-import { readFileSync } from 'fs';
+import * as fs from 'fs';
 
 export { Object_ as Object, Array_ as Array };
 
@@ -106,10 +105,10 @@ export function stringify(value: Value): string {
 
 /** Synchronously reads a text file and parses it as JSON. */
 export function loadSync(path: string, encoding: BufferEncoding = 'utf8'): Value {
-    return parse(readFileSync(path, encoding));
+    return parse(fs.readFileSync(path, encoding));
 }
 
 export async function load(path: string, encoding: BufferEncoding = 'utf8'): Promise<Value> {
-    let source = await readFile(path, encoding);
+    let source = await fs.promises.readFile(path, encoding);
     return parse(source);
 }


### PR DESCRIPTION
Change `require('fs/promises')` to `require('fs').promises` for Node 10 compatibility.